### PR TITLE
Requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "description.md"), encoding="utf-8") as f:
     long_description = f.read()
 
+test_deps = ["python-dotenv==0.20.0", "pytest==7.1.3"]
+extras = {'test': test_deps}
+
 setup(
     name="heyoo",
     version="0.0.6",
@@ -19,7 +22,11 @@ setup(
     author_email="isaackeinstein@gmail.com",
     license="MIT",
     packages=["heyoo"],
-    install_requires=["requests"],
+    install_requires=["requests==2.28.1",
+                      "Flask==2.2.2",
+                      "requests-toolbelt==0.9.1"],
+    tests_require=test_deps,
+    extras_require=extras,
     keywords=[
         "heyoo",
         "heyoo-libary",


### PR DESCRIPTION
This adds the requirements to the `setup.py` file so they are installed with the package. #31 
In the future the versions have to be changed in to place / or the `requirements.txt` can be removed.

Dependenvies that are only used for testing/the examples are listed as `extras_require` and can be installed using `pip install heyoo[test]`