### PR TITLE
Fix components error

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ You can find the available components in the documentation.
 <https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates>
 
 ```python
->>> messenger.send_template("hello_world", "255757xxxxxx", components={})
+>>> messenger.send_template("hello_world", "255757xxxxxx", components=[])
 ```
 
 ## Webhook


### PR DESCRIPTION
As said by the docs, components element should be a list containing a dictionary, like [{"key": "value"}], so is better to use [] in the example.