### PR TITLE
More loosely select dependendency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email="isaackeinstein@gmail.com",
     license="MIT",
     packages=["heyoo"],
-    install_requires=["requests==2.28.1", "Flask==2.2.2", "requests-toolbelt==0.9.1"],
+    install_requires=["requests>=2.28.1", "Flask>=2.2.2", "requests-toolbelt>=0.9.1"],
     tests_require=test_deps,
     extras_require=extras,
     keywords=[


### PR DESCRIPTION
Currently this project is very strict regarding the dependency version it uses. This means that it doesn't work nicely with project that require version freezing, cause it will generate conflict if it has the same dependency in the project but a different version for some reason. This is likely to happen a lot with the `requests` package since it's widely used or even another project using flask.

Version freezing should be reserved to the main project, not an external lib, unless it actually requires a specific version. As far as I can see there's no reason to use the exact specific version, so I'm proposing to change it to a more loose version requirement.