### PR TITLE
security [HIGH]: disable debug 

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -102,4 +102,4 @@ def hook():
 
 
 if __name__ == "__main__":
-    app.run(port=5000, debug=True)
+    app.run(port=5000, debug=False)


### PR DESCRIPTION
The debug in the hook was enabled by default, making the app easily exploitable once it was online. 