### PR TITLE
Fixed mark_as_read function

### DIFF
--- a/heyoo/__init__.py
+++ b/heyoo/__init__.py
@@ -573,10 +573,10 @@ class WhatsApp(object):
             f"{self.v15_base_url}/{self.phone_number_id}/messages",
             headers=headers,
             json=json_data,
-        ).json()
+        )
         if response.status_code == 200:
             logging.info(f"Message {message_id} marked as read")
-            return response
+            return response.json()
         logging.info(f"Error marking message {message_id} as read")
         logging.info(f"Status code: {response.status_code}")
         logging.info(f"Response: {response.json()}")


### PR DESCRIPTION
Fixed the error :
```
File "C:\Python311\Lib\site-packages\heyoo\__init__.py", line 583, in mark_as_read
    if response.status_code == 200:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'status_code'
```
Although i know #92 exists, i believe my fix is better as it is consistent with the rest of the code.

In the following examples, the request only converts to json when either returning successfully, or logging an error. 

- https://github.com/Neurotech-HQ/heyoo/blob/36eb23d3a9a88cc9e819a0fbd0cdc9a790f801e7/heyoo/__init__.py#L516-L526
- https://github.com/Neurotech-HQ/heyoo/blob/36eb23d3a9a88cc9e819a0fbd0cdc9a790f801e7/heyoo/__init__.py#L537-L543
- https://github.com/Neurotech-HQ/heyoo/blob/36eb23d3a9a88cc9e819a0fbd0cdc9a790f801e7/heyoo/__init__.py#L620-L626
- https://github.com/Neurotech-HQ/heyoo/blob/36eb23d3a9a88cc9e819a0fbd0cdc9a790f801e7/heyoo/__init__.py#L649-L655
- https://github.com/Neurotech-HQ/heyoo/blob/36eb23d3a9a88cc9e819a0fbd0cdc9a790f801e7/heyoo/__init__.py#L675-L681