### PR TITLE
Only add typing requirement if python version is <3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email="isaackeinstein@gmail.com",
     license="MIT",
     packages=["heyoo"],
-    install_requires=["requests>=2.28.1", "requests-toolbelt>=0.9.1", "colorama", "typing"],
+    install_requires=["requests>=2.28.1", "requests-toolbelt>=0.9.1", "colorama", "typing;python_version<'3.5'"],
     tests_require=test_deps,
     extras_require=extras,
     keywords=[


### PR DESCRIPTION
I'm having some issues in AWS with this package.

this change is a recommendation from the package maintainers:  https://pypi.org/project/typing/
> For package maintainers, it is preferred to use typing;python_version<"3.5" if your package requires it to support earlier Python versions. This will avoid shadowing the stdlib typing module when your package is installed via pip install -t . on Python 3.5 or later.

and I also saw this setup change in another project: https://github.com/hardbyte/python-can/pull/452
